### PR TITLE
Add stream replay for late-joining clients

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,10 @@ jobs:
         working-directory: packages/wmux-client
         run: bun run build
 
+      - name: Run echoform tests
+        working-directory: packages/echoform
+        run: bun run test
+
       - name: Install Playwright browsers
         run: bunx playwright install --with-deps chromium
 

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
     },
     "demo/dev-server": {
       "name": "@demo/dev-server",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "dependencies": {
         "@playfast/wmux": "workspace:*",
         "react": "^19.0.0",
@@ -28,7 +28,7 @@
     },
     "demo/file-editor": {
       "name": "file-editor-demo",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "dependencies": {
         "@playfast/echoform": "workspace:*",
         "@playfast/echoform-bun-ws-client": "workspace:*",
@@ -73,7 +73,7 @@
     },
     "demo/todo-app": {
       "name": "todo-app-demo",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "dependencies": {
         "@playfast/echoform": "workspace:*",
         "@playfast/echoform-bun-ws-client": "workspace:*",
@@ -96,13 +96,14 @@
     },
     "packages/echoform": {
       "name": "@playfast/echoform",
-      "version": "1.0.2",
+      "version": "1.0.4",
       "dependencies": {
         "crypto-random-string": "5.0.0",
         "fossil-delta": "^2.0.0",
         "typed-binary": "^4.3.3",
       },
       "devDependencies": {
+        "@playfast/echoform-render": "workspace:*",
         "@types/react": "19.0.2",
         "react": "19.0.0",
       },
@@ -112,7 +113,7 @@
     },
     "packages/react-render-null": {
       "name": "@playfast/echoform-render",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "dependencies": {
         "@types/react-reconciler": "0.28.9",
         "react-reconciler": "0.31.0",
@@ -123,13 +124,13 @@
         "react": "19.0.0",
       },
       "peerDependencies": {
-        "@playfast/echoform": ">=1.0.2",
+        "@playfast/echoform": ">=1.0.4",
         "react": ">=19.0.0",
       },
     },
     "packages/wmux": {
       "name": "@playfast/wmux",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "dependencies": {
         "@playfast/echoform": "workspace:*",
         "@playfast/echoform-render": "workspace:*",
@@ -145,7 +146,7 @@
     },
     "packages/wmux-client": {
       "name": "@playfast/wmux-client",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "dependencies": {
         "@dnd-kit/react": "^0.3.2",
         "@heroui/react": "^3.0.0",
@@ -173,33 +174,33 @@
     },
     "plugins/bun-ws-client": {
       "name": "@playfast/echoform-bun-ws-client",
-      "version": "1.0.2",
+      "version": "1.0.4",
       "devDependencies": {
         "@playfast/echoform": "workspace:*",
         "@types/react": "19.0.2",
         "@types/react-dom": "19.0.2",
       },
       "peerDependencies": {
-        "@playfast/echoform": ">=1.0.2",
+        "@playfast/echoform": ">=1.0.4",
         "react": ">=19.0.0",
         "react-dom": ">=19.0.0",
       },
     },
     "plugins/bun-ws-server": {
       "name": "@playfast/echoform-bun-ws-server",
-      "version": "1.0.2",
+      "version": "1.0.4",
       "devDependencies": {
         "@playfast/echoform": "workspace:*",
         "@types/react": "19.0.2",
       },
       "peerDependencies": {
-        "@playfast/echoform": ">=1.0.2",
+        "@playfast/echoform": ">=1.0.4",
         "react": ">=19.0.0",
       },
     },
     "plugins/socket-client": {
       "name": "@playfast/echoform-socket-client",
-      "version": "1.0.2",
+      "version": "1.0.4",
       "dependencies": {
         "socket.io-client": "4.8.3",
       },
@@ -209,14 +210,14 @@
         "@types/react-dom": "19.0.2",
       },
       "peerDependencies": {
-        "@playfast/echoform": ">=1.0.2",
+        "@playfast/echoform": ">=1.0.4",
         "react": ">=19.0.0",
         "react-dom": ">=19.0.0",
       },
     },
     "plugins/socket-server": {
       "name": "@playfast/echoform-socket-server",
-      "version": "1.0.2",
+      "version": "1.0.4",
       "dependencies": {
         "socket.io": "4.8.3",
       },
@@ -230,7 +231,7 @@
         "utf-8-validate": "5.0.10",
       },
       "peerDependencies": {
-        "@playfast/echoform": ">=1.0.2",
+        "@playfast/echoform": ">=1.0.4",
         "react": ">=19.0.0",
       },
     },

--- a/demo/dev-server/test/e2e.test.ts
+++ b/demo/dev-server/test/e2e.test.ts
@@ -7,6 +7,9 @@ const WMUX_URL = "/#token=test-token&ws=ws://localhost:4220/ws";
 // Selector for xterm inside the visible (active) tab panel
 const VISIBLE_XTERM = "[style*='visibility: visible'] .xterm";
 
+// xterm-rows contains terminal text as readable DOM nodes
+const XTERM_ROWS = "[style*='visibility: visible'] .xterm-rows";
+
 test.describe("Terminal E2E", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto(WMUX_URL);
@@ -30,5 +33,54 @@ test.describe("Terminal E2E", () => {
     // Sidebar should render category sections
     await expect(page.getByText("background")).toBeVisible({ timeout: 5000 });
     await expect(page.getByText("interactive")).toBeVisible({ timeout: 5000 });
+  });
+});
+
+test.describe("Stream Replay E2E", () => {
+  test("late-joining client receives terminal history", async ({ browser }) => {
+    // Page 1: connect and ensure counter tab is active
+    const ctx1 = await browser.newContext();
+    const page1 = await ctx1.newPage();
+    await page1.goto(WMUX_URL);
+    await page1.waitForSelector(VISIBLE_XTERM, { state: "visible", timeout: 15000 });
+
+    // Ensure we're on the counter tab (first tab in background category)
+    await page1.getByText("counter", { exact: true }).click();
+    await page1.waitForTimeout(500);
+
+    // Wait for ticks to accumulate in the replay buffer
+    await page1.waitForFunction(
+      (sel: string) => {
+        const tree = document.querySelector(sel);
+        return tree?.textContent?.includes("tick") ?? false;
+      },
+      XTERM_ROWS,
+      { timeout: 10000 },
+    );
+
+    // Page 2: late joiner opens a fresh context (new WebSocket connection)
+    const ctx2 = await browser.newContext();
+    const page2 = await ctx2.newPage();
+    await page2.goto(WMUX_URL);
+    await page2.waitForSelector(VISIBLE_XTERM, { state: "visible", timeout: 15000 });
+
+    // Ensure counter tab is selected on page 2 as well
+    await page2.getByText("counter", { exact: true }).click();
+    await page2.waitForTimeout(500);
+
+    // The late joiner should see replayed terminal content with "tick"
+    const hasReplay = await page2.waitForFunction(
+      (sel: string) => {
+        const tree = document.querySelector(sel);
+        return tree?.textContent?.includes("tick") ?? false;
+      },
+      XTERM_ROWS,
+      { timeout: 10000 },
+    );
+
+    expect(hasReplay).toBeTruthy();
+
+    await ctx1.close();
+    await ctx2.close();
   });
 });

--- a/packages/echoform/package.json
+++ b/packages/echoform/package.json
@@ -30,7 +30,8 @@
   ],
   "scripts": {
     "typecheck": "tsgo -p .",
-    "build": "tsgo -p ."
+    "build": "tsgo -p .",
+    "test": "bun test tests/"
   },
   "peerDependencies": {
     "react": ">=19.0.0"
@@ -41,6 +42,7 @@
     "typed-binary": "^4.3.3"
   },
   "devDependencies": {
+    "@playfast/echoform-render": "workspace:*",
     "@types/react": "19.0.2",
     "react": "19.0.0"
   },

--- a/packages/echoform/src/client/Client.tsx
+++ b/packages/echoform/src/client/Client.tsx
@@ -65,6 +65,7 @@ function Client<TEvents extends Record<string | number, unknown> = Record<string
   const [runningViews, setRunningViews] = useState<ReadonlyArray<ExistingSharedViewData>>([]);
   const transportRef = useRef(decompileTransport(rawTransport));
   const streamListenersRef = useRef<Map<StreamUid, Set<(chunk: SerializableValue) => void>>>(new Map());
+  const pendingReplayRef = useRef<Map<StreamUid, ReadonlyArray<SerializableValue>>>(new Map());
 
   const createEvent = useCallback((eventUid: EventUid, ...args: ReadonlyArray<SerializableValue>): Promise<SerializableValue> => {
     return new Promise((resolve, reject) => {
@@ -105,6 +106,16 @@ function Client<TEvents extends Record<string | number, unknown> = Record<string
     const newSet = new Set(existing);
     newSet.add(listener);
     streamListenersRef.current = new Map([...streamListenersRef.current, [streamUid, newSet]]);
+
+    const pending = pendingReplayRef.current.get(streamUid);
+    if (pending) {
+      const updated = new Map(pendingReplayRef.current);
+      updated.delete(streamUid);
+      pendingReplayRef.current = updated;
+      for (const chunk of pending) {
+        listener(chunk);
+      }
+    }
 
     return () => {
       const current = streamListenersRef.current.get(streamUid);
@@ -151,11 +162,28 @@ function Client<TEvents extends Record<string | number, unknown> = Record<string
       streamListenersRef.current = newMap;
     };
 
+    const streamReplayHandler = ({ streamUid, chunks }: AppEvents['stream_replay']): void => {
+      const listeners = streamListenersRef.current.get(streamUid);
+      if (listeners && listeners.size > 0) {
+        for (const chunk of chunks) {
+          for (const listener of listeners) {
+            listener(chunk);
+          }
+        }
+      } else {
+        pendingReplayRef.current = new Map([
+          ...pendingReplayRef.current,
+          [streamUid, chunks],
+        ]);
+      }
+    };
+
     const unsubscribeViewsTree = transport.on("update_views_tree", updateViewsTreeHandler);
     const unsubscribeUpdateView = transport.on("update_view", updateViewHandler);
     const unsubscribeDeleteView = transport.on("delete_view", deleteViewHandler);
     const unsubscribeStreamChunk = transport.on("stream_chunk", streamChunkHandler);
     const unsubscribeStreamEnd = transport.on("stream_end", streamEndHandler);
+    const unsubscribeStreamReplay = transport.on("stream_replay", streamReplayHandler);
 
     if (requestViewTreeOnMount) {
       transport.emit("request_views_tree");
@@ -167,7 +195,9 @@ function Client<TEvents extends Record<string | number, unknown> = Record<string
       unsubscribeDeleteView?.();
       unsubscribeStreamChunk?.();
       unsubscribeStreamEnd?.();
+      unsubscribeStreamReplay?.();
       streamListenersRef.current = new Map();
+      pendingReplayRef.current = new Map();
       transport.destroy();
     };
   }, [requestViewTreeOnMount]);

--- a/packages/echoform/src/server/App.tsx
+++ b/packages/echoform/src/server/App.tsx
@@ -13,6 +13,7 @@ import type {
 import type { EventUid, RequestUid, ViewUid, StreamUid, PropName } from "../shared/branded.types";
 import { createEventUid, createPropName } from "../shared/branded.types";
 import type { StreamEmitterHandle } from "../shared/view-inference";
+import type { StreamBufferGetter } from "./contexts";
 import { getViewDef } from "../shared/view-builder";
 import { ViewFactoryContext } from "../shared/view-factory";
 import type { ViewFactory } from "../shared/view-factory";
@@ -263,10 +264,17 @@ function handleViewsTreeRequest(
   client: DecompileTransport,
   existingSharedViewsRef: React.RefObject<ReadonlyArray<ExistingSharedViewData>>,
   clientEventAuthRef: React.RefObject<Map<DecompileTransport, Set<EventUid>>>,
+  streamBufferRegistryRef: React.RefObject<Map<StreamUid, StreamBufferGetter>>,
 ): void {
   client.emit("update_views_tree", { views: snapshotViews(existingSharedViewsRef.current) });
   const allEventUids = existingSharedViewsRef.current.flatMap((v) => collectEventUids(v.props));
   clientEventAuthRef.current = new Map([...clientEventAuthRef.current, [client, new Set(allEventUids)]]);
+
+  for (const [streamUid, getBuffer] of streamBufferRegistryRef.current) {
+    const chunks = getBuffer();
+    if (chunks.length === 0) continue;
+    client.emit("stream_replay", { streamUid, chunks });
+  }
 }
 
 function createNewSharedView(
@@ -328,6 +336,7 @@ const App = forwardRef<AppHandle, AppProps>(function App({ children, transport, 
   const clientCleanupMapRef = useRef<Map<AnyTransport, () => void>>(new Map());
   const clientEventAuthRef = useRef<Map<DecompileTransport, Set<EventUid>>>(new Map());
   const eventChainRef = useRef(Promise.resolve());
+  const streamBufferRegistryRef = useRef<Map<StreamUid, StreamBufferGetter>>(new Map());
   const skipValidationRef = useRef(skipCallbackValidation ?? false);
   skipValidationRef.current = skipCallbackValidation ?? false;
 
@@ -352,11 +361,24 @@ const App = forwardRef<AppHandle, AppProps>(function App({ children, transport, 
 
   const broadcastStreamEnd = useCallback((streamUid: StreamUid): void => {
     broadcast("stream_end", { streamUid });
+    const updated = new Map(streamBufferRegistryRef.current);
+    updated.delete(streamUid);
+    streamBufferRegistryRef.current = updated;
   }, [broadcast]);
+
+  const registerStreamBuffer = useCallback((streamUid: StreamUid, getBuffer: StreamBufferGetter): void => {
+    streamBufferRegistryRef.current = new Map([...streamBufferRegistryRef.current, [streamUid, getBuffer]]);
+  }, []);
+
+  const unregisterStreamBuffer = useCallback((streamUid: StreamUid): void => {
+    const updated = new Map(streamBufferRegistryRef.current);
+    updated.delete(streamUid);
+    streamBufferRegistryRef.current = updated;
+  }, []);
 
   const registerSocketListener = useCallback((client: DecompileTransport) => {
     const cleanReqTree = client.on("request_views_tree", () => {
-      handleViewsTreeRequest(client, existingSharedViewsRef, clientEventAuthRef);
+      handleViewsTreeRequest(client, existingSharedViewsRef, clientEventAuthRef, streamBufferRegistryRef);
     });
 
     const cleanReqEvent = client.on("request_event", (eventData: AppEvents['request_event']) => {
@@ -433,8 +455,12 @@ const App = forwardRef<AppHandle, AppProps>(function App({ children, transport, 
     removeEventHandlers(viewEventsRef, deleteSet);
     clientEventAuthRef.current = deauthorizeEventUidsForAllClients(clientEventAuthRef.current, deleteSet);
 
+    for (const prop of deletedView.props) {
+      if (prop.type === "stream") unregisterStreamBuffer(prop.uid);
+    }
+
     broadcast("delete_view", { viewUid: uid });
-  }, [broadcast]);
+  }, [broadcast, unregisterStreamBuffer]);
 
   useEffect(() => {
     if (!transportIsClient) return;
@@ -469,7 +495,8 @@ const App = forwardRef<AppHandle, AppProps>(function App({ children, transport, 
     views: snapshotViews(existingSharedViewsRef.current),
     addClient, removeClient, updateRunningView, deleteRunningView,
     broadcastStreamChunk, broadcastStreamEnd,
-  }), [addClient, removeClient, updateRunningView, deleteRunningView, broadcastStreamChunk, broadcastStreamEnd]);
+    registerStreamBuffer, unregisterStreamBuffer,
+  }), [addClient, removeClient, updateRunningView, deleteRunningView, broadcastStreamChunk, broadcastStreamEnd, registerStreamBuffer, unregisterStreamBuffer]);
 
   const viewFactory = useCallback<ViewFactory>(
     (name, props) => <ViewComponent name={name} props={props} />,

--- a/packages/echoform/src/server/contexts.ts
+++ b/packages/echoform/src/server/contexts.ts
@@ -1,6 +1,9 @@
 import React from "react";
 import type { ViewData, ExistingSharedViewData, Transport, SerializableValue } from "../shared/types";
 import type { ViewUid, StreamUid } from "../shared/branded.types";
+
+export type StreamBufferGetter = () => ReadonlyArray<SerializableValue>;
+
 export interface AppContextValue {
   readonly views: ReadonlyArray<ExistingSharedViewData>;
   readonly addClient: <TClientEvents extends Record<string | number, unknown>>(client: Transport<TClientEvents>) => void;
@@ -9,6 +12,8 @@ export interface AppContextValue {
   readonly deleteRunningView: (uid: ViewUid) => void;
   readonly broadcastStreamChunk: (streamUid: StreamUid, chunk: SerializableValue) => void;
   readonly broadcastStreamEnd: (streamUid: StreamUid) => void;
+  readonly registerStreamBuffer: (streamUid: StreamUid, getBuffer: StreamBufferGetter) => void;
+  readonly unregisterStreamBuffer: (streamUid: StreamUid) => void;
 }
 
 export const AppContext = React.createContext<AppContextValue | undefined>(undefined);

--- a/packages/echoform/src/server/utils.tsx
+++ b/packages/echoform/src/server/utils.tsx
@@ -10,6 +10,9 @@ import type { StandardSchemaV1 } from "../shared/standard-schema";
 /**
  * Create a StreamEmitter for a server-to-client stream prop.
  *
+ * If the stream was defined with `{ replay: N }`, the emitter automatically
+ * buffers the last N chunks and replays them to newly connected clients.
+ *
  * ```ts
  * const output = useStream(TerminalDef, "output");
  * output.emit({ data: "hello" });
@@ -27,11 +30,19 @@ export function useStream<
 
   if (!emitterRef.current) {
     const uid = createStreamUid(randomId());
-    emitterRef.current = createStreamEmitter(
+    const streamDef = _viewDef.streams[_streamName] as StreamDef | undefined;
+    const replaySize = streamDef?.replay;
+    const emitter = createStreamEmitter(
       uid,
       (streamUid, chunk) => app?.broadcastStreamChunk(streamUid, chunk),
       (streamUid) => app?.broadcastStreamEnd(streamUid),
+      replaySize,
     );
+    emitterRef.current = emitter;
+
+    if (replaySize !== undefined && replaySize > 0) {
+      app?.registerStreamBuffer(uid, emitter.getBuffer);
+    }
   }
 
   return emitterRef.current as StreamEmitter<V["streams"][K] extends StreamDef<infer C> ? StandardSchemaV1.InferInput<C> : never>;

--- a/packages/echoform/src/shared/binary-protocol.ts
+++ b/packages/echoform/src/shared/binary-protocol.ts
@@ -230,6 +230,7 @@ const EVENT_RESPOND_TO_EVENT = 4;
 const EVENT_REQUEST_EVENT = 5;
 const EVENT_STREAM_CHUNK = 6;
 const EVENT_STREAM_END = 7;
+const EVENT_STREAM_REPLAY = 8;
 const EVENT_FALLBACK = 0xFF;
 
 const updateViewsTreeSchema = object({ views: dynamicArrayOf(existingViewDataSchema) });
@@ -238,6 +239,7 @@ const deleteViewSchema = object({ viewUid: binString });
 const requestEventSchema = object({ eventArguments: dynamicArrayOf(serializableValue), uid: binString, eventUid: binString });
 const streamChunkSchema = object({ streamUid: binString, chunk: serializableValue });
 const streamEndSchema = object({ streamUid: binString });
+const streamReplaySchema = object({ streamUid: binString, chunks: dynamicArrayOf(serializableValue) });
 
 const voidSchema = createSchema<void>({
   write() {},
@@ -286,6 +288,7 @@ const eventSchemas: ReadonlyArray<ISchema<any>> = [
   requestEventSchema,     // 5
   streamChunkSchema,      // 6
   streamEndSchema,        // 7
+  streamReplaySchema,     // 8
 ];
 
 // ---- Lookup tables ----
@@ -299,11 +302,13 @@ const eventNameToId: Record<string, number> = {
   request_event: EVENT_REQUEST_EVENT,
   stream_chunk: EVENT_STREAM_CHUNK,
   stream_end: EVENT_STREAM_END,
+  stream_replay: EVENT_STREAM_REPLAY,
 };
 
 const idToEventName: readonly string[] = [
   "update_views_tree", "update_view", "delete_view", "request_views_tree",
   "respond_to_event", "request_event", "stream_chunk", "stream_end",
+  "stream_replay",
 ];
 
 // ---- Wire message: encode/decode ----

--- a/packages/echoform/src/shared/decompiled-transport.ts
+++ b/packages/echoform/src/shared/decompiled-transport.ts
@@ -191,6 +191,10 @@ function applyBrands(event: string, data: unknown): unknown {
       const endPayload = data as { readonly streamUid: string };
       return { streamUid: createStreamUid(endPayload.streamUid) };
     }
+    case "stream_replay": {
+      const replayPayload = data as { readonly streamUid: string; readonly chunks: ReadonlyArray<unknown> };
+      return { streamUid: createStreamUid(replayPayload.streamUid), chunks: replayPayload.chunks };
+    }
     default:
       return data;
   }
@@ -234,6 +238,7 @@ function emitFactory(): EmitFunctions {
     request_event: createEmitFn("request_event"),
     stream_chunk: createEmitFn("stream_chunk"),
     stream_end: createEmitFn("stream_end"),
+    stream_replay: createEmitFn("stream_replay"),
   };
 }
 

--- a/packages/echoform/src/shared/index.ts
+++ b/packages/echoform/src/shared/index.ts
@@ -23,7 +23,7 @@ export type {
 
 // View builder API
 export { view, callback, stream, createViews, passthrough, getViewDef } from "./view-builder";
-export type { ViewDef, CallbackDef, StreamDef, ViewDefs, ViewConfig, CallbackConfig, ServerView } from "./view-builder";
+export type { ViewDef, CallbackDef, StreamDef, StreamOptions, ViewDefs, ViewConfig, CallbackConfig, ServerView } from "./view-builder";
 export { ViewFactoryContext } from "./view-factory";
 export type { ViewFactory } from "./view-factory";
 export type { InferServerProps, InferClientProps, StreamEmitter, StreamReceiver, StreamEmitterHandle, ClientCallback } from "./view-inference";

--- a/packages/echoform/src/shared/types.ts
+++ b/packages/echoform/src/shared/types.ts
@@ -54,6 +54,10 @@ export interface AppEvents {
   readonly stream_end: {
     readonly streamUid: StreamUid;
   };
+  readonly stream_replay: {
+    readonly streamUid: StreamUid;
+    readonly chunks: ReadonlyArray<SerializableValue>;
+  };
 }
 
 export interface ViewDataBase {

--- a/packages/echoform/src/shared/view-builder.ts
+++ b/packages/echoform/src/shared/view-builder.ts
@@ -28,10 +28,15 @@ export interface CallbackConfig<
 
 // ---- StreamDef ----
 
+export interface StreamOptions {
+  readonly replay?: number | undefined;
+}
+
 export interface StreamDef<
   TChunk extends StandardSchemaV1 = StandardSchemaV1,
 > {
   readonly chunk: TChunk;
+  readonly replay?: number | undefined;
 }
 
 // ---- ViewDef ----
@@ -138,15 +143,21 @@ export function callback<
 /**
  * Define a server-to-client stream with a chunk schema.
  *
+ * Optionally pass `{ replay: N }` to buffer the last N chunks server-side.
+ * New clients receive the buffered chunks on connect (ReplaySubject pattern).
+ *
  * ```ts
- * stream(z.object({ data: z.string() }))
+ * stream(z.string())                      // no replay
+ * stream(z.string(), { replay: 1000 })    // buffer last 1000 chunks
  * ```
  */
 export function stream<TChunk extends StandardSchemaV1>(
   chunkSchema: TChunk,
+  options?: StreamOptions,
 ): StreamDef<TChunk> {
   return {
     chunk: chunkSchema,
+    ...(options?.replay !== undefined ? { replay: options.replay } : {}),
   };
 }
 

--- a/packages/echoform/src/shared/view-inference.ts
+++ b/packages/echoform/src/shared/view-inference.ts
@@ -27,17 +27,30 @@ export interface StreamReceiver<T> {
 
 export interface StreamEmitterHandle<T = unknown> extends StreamEmitter<T> {
   readonly uid: StreamUid;
+  readonly getBuffer: () => ReadonlyArray<SerializableValue>;
 }
 
 export function createStreamEmitter<T>(
   uid: StreamUid,
   onChunk: (streamUid: StreamUid, chunk: SerializableValue) => void,
   onEnd: (streamUid: StreamUid) => void,
+  restoreSize?: number | undefined,
 ): StreamEmitterHandle<T> {
+  const buffer: SerializableValue[] = [];
+  const capacity = restoreSize ?? 0;
+
   return {
     uid,
-    emit: (chunk: T) => onChunk(uid, chunk as SerializableValue),
+    emit: (chunk: T) => {
+      const serialized = chunk as SerializableValue;
+      if (capacity > 0) {
+        if (buffer.length >= capacity) buffer.shift();
+        buffer.push(serialized);
+      }
+      onChunk(uid, serialized);
+    },
     end: () => onEnd(uid),
+    getBuffer: () => [...buffer],
   };
 }
 

--- a/packages/echoform/tests/stream-replay.test.ts
+++ b/packages/echoform/tests/stream-replay.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Protocol-level integration test for stream replay.
+ *
+ * Spins up a minimal echoform server with a stream that has replay enabled,
+ * connects two WebSocket clients sequentially, and verifies the second client
+ * receives a `stream_replay` message with buffered chunks.
+ */
+import { describe, test, expect, afterAll } from "bun:test";
+import React from "react";
+import { view, stream, passthrough, createViews } from "../src/shared/view-builder";
+import { Server } from "../src/server/Server";
+import { useStream } from "../src/server/utils";
+import { Render } from "@playfast/echoform-render";
+import { decodeMessage, encodeMessage } from "../src/shared/binary-protocol";
+
+const TEST_TOKEN = "test-replay-token";
+
+const TestView = view("TestView", {
+  input: { label: passthrough<string>() },
+  streams: { output: stream(passthrough<string>(), { replay: 50 }) },
+});
+
+const views = createViews({ TestView });
+
+interface ServerHandle {
+  readonly port: number;
+  readonly stop: () => void;
+}
+
+function createTestServer(): ServerHandle {
+  type ClientEntry = {
+    readonly dispatch: (msg: string | ArrayBuffer | Uint8Array) => void;
+    readonly disconnect: () => void;
+  };
+
+  const clients = new Map<string, ClientEntry>();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let connectionHandler: ((client: any) => void) | null = null;
+
+  const transport = {
+    on: (_event: string, handler: (data: unknown) => void) => { connectionHandler = handler; },
+    emit: () => {},
+    off: () => { connectionHandler = null; },
+  };
+
+  let emitChunk: ((chunk: string) => void) | null = null;
+
+  function StreamProducer(): React.ReactElement {
+    const output = useStream(TestView, "output");
+    emitChunk = (chunk: string) => output.emit(chunk);
+    return React.createElement(TestView, { label: "test", output });
+  }
+
+  const server = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    fetch(req, srv) {
+      const url = new URL(req.url);
+      if (url.pathname === "/ws") {
+        const token = url.searchParams.get("token");
+        if (token !== TEST_TOKEN) return new Response("Unauthorized", { status: 401 });
+        const upgraded = srv.upgrade(req, {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          data: { id: globalThis.crypto.randomUUID() } as any,
+        });
+        if (upgraded) return undefined;
+        return new Response("Upgrade failed", { status: 500 });
+      }
+      return new Response("Not found", { status: 404 });
+    },
+    websocket: {
+      open(ws) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const data = ws.data as any;
+        const id = data.id as string;
+
+        const { createWebSocketTransport } = require("../src/shared/transport-handlers");
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const { transport: clientTransport, dispatch, disconnect } = createWebSocketTransport(ws as any);
+        clients.set(id, { dispatch, disconnect });
+        connectionHandler?.({ ...clientTransport, id });
+      },
+      message(ws, message) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const data = ws.data as any;
+        const client = clients.get(data.id as string);
+        if (client) client.dispatch(message as string | ArrayBuffer | Uint8Array);
+      },
+      close(ws) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const data = ws.data as any;
+        const client = clients.get(data.id as string);
+        if (client) {
+          client.disconnect();
+          clients.delete(data.id as string);
+        }
+      },
+    },
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Render(React.createElement(Server, { transport: transport as any, singleInstance: true }, () => React.createElement(StreamProducer)));
+
+  // Wait a tick for React to mount, then emit chunks
+  setTimeout(() => {
+    for (let i = 0; i < 10; i++) {
+      emitChunk?.(`chunk-${i}`);
+    }
+  }, 100);
+
+  return {
+    port: server.port,
+    stop: () => {
+      server.stop();
+      clients.clear();
+    },
+  };
+}
+
+interface ReceivedMessages {
+  readonly streamChunks: ReadonlyArray<{ readonly streamUid: string; readonly chunk: string }>;
+  readonly streamReplays: ReadonlyArray<{ readonly streamUid: string; readonly chunks: ReadonlyArray<string> }>;
+}
+
+function connectClient(port: number): Promise<{ readonly messages: ReceivedMessages; readonly close: () => void }> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws?token=${TEST_TOKEN}`);
+
+    const streamChunks: Array<{ streamUid: string; chunk: string }> = [];
+    const streamReplays: Array<{ streamUid: string; chunks: Array<string> }> = [];
+
+    ws.binaryType = "arraybuffer";
+
+    ws.addEventListener("open", () => {
+      // Request the view tree (triggers replay for streams with buffers)
+      const requestMsg = encodeMessage("request_views_tree", undefined);
+      ws.send(requestMsg);
+    });
+
+    ws.addEventListener("message", (event) => {
+      const bytes = new Uint8Array(event.data as ArrayBuffer);
+      const { event: eventName, data } = decodeMessage(bytes);
+
+      if (eventName === "stream_chunk") {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const payload = data as any;
+        streamChunks.push({ streamUid: payload.streamUid, chunk: payload.chunk });
+      }
+      if (eventName === "stream_replay") {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const payload = data as any;
+        streamReplays.push({ streamUid: payload.streamUid, chunks: payload.chunks });
+      }
+    });
+
+    // Give the client a moment to receive messages after connecting
+    setTimeout(() => {
+      resolve({
+        messages: { streamChunks, streamReplays },
+        close: () => ws.close(),
+      });
+    }, 500);
+
+    ws.addEventListener("error", reject);
+  });
+}
+
+describe("Stream Replay", () => {
+  let server: ServerHandle;
+
+  afterAll(() => {
+    server?.stop();
+  });
+
+  test("second client receives stream_replay with buffered chunks", async () => {
+    server = createTestServer();
+
+    // Wait for server to emit chunks
+    await new Promise((r) => setTimeout(r, 300));
+
+    // Client 1: connects and receives live stream_chunk events
+    const client1 = await connectClient(server.port);
+    expect(client1.messages.streamReplays.length).toBeGreaterThan(0);
+
+    // The replay should contain our emitted chunks
+    const replayChunks = client1.messages.streamReplays[0]!.chunks;
+    expect(replayChunks).toContain("chunk-0");
+    expect(replayChunks).toContain("chunk-9");
+    expect(replayChunks.length).toBe(10);
+
+    // Client 2: late joiner should also get replay
+    const client2 = await connectClient(server.port);
+    expect(client2.messages.streamReplays.length).toBeGreaterThan(0);
+
+    const replay2Chunks = client2.messages.streamReplays[0]!.chunks;
+    expect(replay2Chunks).toContain("chunk-0");
+    expect(replay2Chunks).toContain("chunk-9");
+    expect(replay2Chunks.length).toBe(10);
+
+    client1.close();
+    client2.close();
+  });
+
+  test("stream without replay does not send stream_replay", async () => {
+    // This test reuses the same server — the view has replay enabled.
+    // We only check that the replay data matches expectations.
+    // A full "no replay" test would need a separate view without replay configured,
+    // but the ring buffer logic ensures capacity=0 means no buffering.
+
+    const { createStreamEmitter } = await import("../src/shared/view-inference");
+    const { createStreamUid } = await import("../src/shared/branded.types");
+
+    const emitter = createStreamEmitter(
+      createStreamUid("no-replay-test"),
+      () => {},
+      () => {},
+      // no restoreSize — defaults to 0
+    );
+
+    emitter.emit("a");
+    emitter.emit("b");
+    emitter.emit("c");
+
+    // Buffer should be empty when no replay configured
+    expect(emitter.getBuffer()).toEqual([]);
+  });
+
+  test("replay buffer respects capacity limit", async () => {
+    const { createStreamEmitter } = await import("../src/shared/view-inference");
+    const { createStreamUid } = await import("../src/shared/branded.types");
+
+    const emitter = createStreamEmitter(
+      createStreamUid("ring-buffer-test"),
+      () => {},
+      () => {},
+      3, // capacity of 3
+    );
+
+    emitter.emit("a");
+    emitter.emit("b");
+    emitter.emit("c");
+    emitter.emit("d");
+    emitter.emit("e");
+
+    // Should only keep last 3
+    expect(emitter.getBuffer()).toEqual(["c", "d", "e"]);
+  });
+});

--- a/packages/wmux/src/views.ts
+++ b/packages/wmux/src/views.ts
@@ -65,7 +65,7 @@ export const WmuxTerminal = view("WmuxTerminal", {
     onResize: callback({ input: z.object({ cols: z.number(), rows: z.number() }) }),
   },
   streams: {
-    output: stream(z.string()),
+    output: stream(z.string(), { replay: 1000 }),
   },
 });
 


### PR DESCRIPTION
## Summary
- Adds `{ replay: N }` option to `stream()` builder — buffers the last N chunks server-side and replays them to newly connected clients (ReplaySubject pattern)
- Fixes wmux terminals showing blank when a second client connects or a client reconnects after process start
- wmux terminal output now uses `stream(z.string(), { replay: 1000 })` by default

## Changes
- **echoform core**: `StreamDef` gains optional `replay` field, `StreamEmitterHandle` gains ring buffer + `getBuffer()`, new `stream_replay` binary protocol event (ID 8)
- **echoform server**: Stream buffer registry in App, replays buffered chunks on `request_views_tree`, cleanup on view delete / stream end
- **echoform client**: Handles `stream_replay` event with pending buffer that flushes on first `subscribe()`
- **wmux**: Terminal output stream configured with `{ replay: 1000 }`

## Test plan
- [ ] Start wmux dev-server, open in browser, verify terminal output appears
- [ ] Open a second browser tab — verify it receives terminal history on connect
- [ ] Close and reopen a tab — verify terminal history is restored
- [ ] Verify streams without `replay` option still work unchanged (backward compat)
- [ ] Run `bun run typecheck` — all packages pass
- [ ] Run `bun run lint` — no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)